### PR TITLE
add GitHub Actions workflow for automatic PR updates from upstream

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,17 @@
+name: Upstream to PR
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+    inputs: {}
+
+jobs:
+  autoupdate:
+    uses: neuro-inc/reuse/.github/workflows/auto-pr.yaml@auto-pr-output
+    with:
+      upstream_repository: https://github.com/hiyouga/LLaMA-Factory
+      upstream_branch: main
+      team_reviewers: 'mlops'
+    secrets:
+      personal_access_token: ${{ secrets.GH_AUTO_PR }}


### PR DESCRIPTION
# What does this PR do?

This pull request introduces a new GitHub Actions workflow to automate the process of creating pull requests from an upstream repository. The workflow is scheduled to run daily and can also be triggered manually.

Automation of pull requests:

* [`.github/workflows/auto-pr.yml`](diffhunk://#diff-66bcf23e63818b74faef47f7f8df000b744f92840970c2e649b491adf936c8a1R1-R17): Added a new workflow named "Upstream to PR" that schedules a job to run at noon every day and allows manual triggering. The job uses a predefined workflow from the `neuro-inc/reuse` repository to create pull requests from the `main` branch of the `LLaMA-Factory` repository, assigning the `mlops` team as reviewers and using a personal access token stored in secrets for authentication.